### PR TITLE
Fix numpy.float32 JSON serialization error

### DIFF
--- a/server/nlweb/analysis.py
+++ b/server/nlweb/analysis.py
@@ -120,7 +120,7 @@ def set_correlation(correlation_array, image_list):
     result = []
     for index, r in enumerate(correlation_array):
         image = image_list[index]
-        result.append({'r': r,
+        result.append({'r': float(r),
                        'id': image['id'],
                        'thumbnail': image['thumbnail'],
                        'collection_id': image['collection_id'],


### PR DESCRIPTION
Explicitly convert numpy value to float to avoid JSON serialization errors which cause failure in some of the model tests.

Background: http://ellisvalentiner.com/post/2016-01-20-numpyfloat64-is-json-serializable-but-numpyfloat32-is-not/